### PR TITLE
Batch lora fix.

### DIFF
--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -472,6 +472,7 @@ class Script(modules.scripts.Script):
             self.usecom = usecom
             if KEYCOMM in p.prompt: # Automatic common toggle.
                 self.usecom = True
+            self.usencom = usencom
             if KEYCOMM in p.negative_prompt: # Automatic common toggle.
                 self.usencom = True
 
@@ -713,7 +714,9 @@ class Script(modules.scripts.Script):
             xt = params.x.clone()
             ict = params.image_cond.clone()
             st =  params.sigma.clone()
-            ct =  params.text_cond.clone()
+            # SBM Stale version workaround.
+            if hasattr(params,"text_cond"):
+                ct =  params.text_cond.clone()
             areas = xt.shape[0] // self.batch_size -1
 
             for a in range(areas):
@@ -721,7 +724,9 @@ class Script(modules.scripts.Script):
                     params.x[b+a*self.batch_size] = xt[a + b * areas]
                     params.image_cond[b+a*self.batch_size] = ict[a + b * areas]
                     params.sigma[b+a*self.batch_size] = st[a + b * areas]
-                    params.text_cond[b+a*self.batch_size] = ct[a + b * areas]
+                    # SBM Stale version workaround.
+                    if hasattr(params,"text_cond"):
+                        params.text_cond[b+a*self.batch_size] = ct[a + b * areas]
 
     def denoised_callback(self, params: CFGDenoisedParams):
         if lactive:

--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -317,6 +317,7 @@ class Script(modules.scripts.Script):
         self.imgcount = 0
         self.filters = []
         self.anded = False
+        self.lora_applied = False
 
     def title(self):
         return "Regional Prompter"
@@ -619,7 +620,9 @@ class Script(modules.scripts.Script):
 
     def process_batch(self, p, active, debug, mode, aratios, bratios, usebase, usecom, usencom, calcmode,nchangeand,**kwargs):
         global lactive,labug
-        if self.active and calcmode =="Latent":
+        if self.lora_applied: # SBM Don't override orig twice on batch calls.
+            pass
+        elif self.active and calcmode =="Latent":
             import lora
             global orig_lora_forward,orig_lora_apply_weights,lactive, orig_lora_Linear_forward, orig_lora_Conv2d_forward
             if hasattr(lora,"lora_apply_weights"): # for new LoRA applying
@@ -642,6 +645,7 @@ class Script(modules.scripts.Script):
                 lora.lora_forward = lora_forward
             lactive = True
             labug = self.debug
+            self.lora_applied = True
             self = lora_namer(self,p)
         else:
             lactive = False
@@ -1118,6 +1122,7 @@ def unloader(self,p):
     global lactive
     lactive = False
     self.active = False
+    self.lora_applied = False
 
 #############################################################
 ##### Preset save and load


### PR DESCRIPTION
Should fix #32 by preventing repeated calls of process_batch (due to batch count > 1 + latent) in the same generation, which might cause some unintended behaviour.

My version's stale so I'm not sure if the whole load (changethedevice) + restoremodel segment should be bypassed, but definitely overriding orig_lora_x more than once causes the function to persist across generations, even when inactive.

Also, a couple other small fixes - not sure why usencom set was dropped, and added a hasattr check for versions before cond/uncond were added (per suggestion in #17).