### PR TITLE
Bugfix for controlnet style transfer + regional.

### DIFF
--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -831,6 +831,11 @@ def hook_forward(self, module):
             outb = None
             if self.usebase:
                 context = contexts[:,tll[i][0] * TOKENSCON:tll[i][1] * TOKENSCON,:]
+                # SBM Controlnet sends extra conds at the end of context, apply it to all regions.
+                cnet_ext = contexts.shape[1] - (contexts.shape[1] // TOKENSCON) * TOKENSCON
+                if cnet_ext > 0:
+                    context = torch.cat([context,contexts[:,-cnet_ext:,:]],dim = 1)
+                    
                 i = i + 1 + self.basebreak
                 out = main_forward(module, x, context, mask, divide, self.isvanilla)
 
@@ -852,6 +857,11 @@ def hook_forward(self, module):
                 for dcell in drow.cols:
                     # Grabs a set of tokens depending on number of unrelated breaks.
                     context = contexts[:,tll[i][0] * TOKENSCON:tll[i][1] * TOKENSCON,:]
+                    # SBM Controlnet sends extra conds at the end of context, apply it to all regions.
+                    cnet_ext = contexts.shape[1] - (contexts.shape[1] // TOKENSCON) * TOKENSCON
+                    if cnet_ext > 0:
+                        context = torch.cat([context,contexts[:,-cnet_ext:,:]],dim = 1)
+                        
                     if self.debug : print(f"tokens : {tll[i][0]*TOKENSCON}-{tll[i][1]*TOKENSCON}")
                     i = i + 1 + dcell.breaks
                     # if i >= contexts.size()[1]: 
@@ -917,6 +927,11 @@ def hook_forward(self, module):
 
             for i, tl in enumerate(tll):
                 context = contexts[:, tl[0] * TOKENSCON : tl[1] * TOKENSCON, :]
+                # SBM Controlnet sends extra conds at the end of context, apply it to all regions.
+                cnet_ext = contexts.shape[1] - (contexts.shape[1] // TOKENSCON) * TOKENSCON
+                if cnet_ext > 0:
+                    context = torch.cat([context,contexts[:,-cnet_ext:,:]],dim = 1)
+                
                 if self.debug : print(f"tokens : {tl[0]*TOKENSCON}-{tl[1]*TOKENSCON}")
 
                 if self.usebase:


### PR DESCRIPTION
Addresses the style transfer issue raised in #23 .

In controlnet's hook, a set of 8 extra values are appended to the end of the pos/neg context. This applies them to each region.

NOTE: Requires a PR merge on controlnet (https://github.com/Mikubill/sd-webui-controlnet/pull/717) to function, otherwise this doesn't do anything (unless there's  some other context symmetry breaking module of which I am unaware).
Repo's been inactive for some time, apparently.