### PR TITLE
Change LoRA Negative settings

### DIFF
--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -426,10 +426,10 @@ class Script(modules.scripts.Script):
                     presetname = gr.Textbox(label="Preset Name",lines=1,value="",interactive=True,elem_id="RP_preset_name",visible=True)
                     savesets = gr.Button(value="Save to Presets",variant='primary',elem_id="RP_savesetting")
             with gr.Row():
-                lnter = gr.Textbox(label="LoRA in negative textencoder",value="0",interactive=True,elem_id="RP_ne_tenc_ratio",visible=True)
-                lnur = gr.Textbox(label="LoRA in negative U-net",value="0",interactive=True,elem_id="RP_ne_unet_ratio",visible=True)
                 nchangeand = gr.Checkbox(value=False, label="disable convert 'AND' to 'BREAK'", interactive=True, elem_id="RP_ncand")
                 debug = gr.Checkbox(value=False, label="debug", interactive=True, elem_id="RP_debug")
+                lnter = gr.Textbox(label="LoRA in negative textencoder",value="0",interactive=True,elem_id="RP_ne_tenc_ratio",visible=True)
+                lnur = gr.Textbox(label="LoRA in negative U-net",value="0",interactive=True,elem_id="RP_ne_unet_ratio",visible=True)
             settings = [mode, ratios, baseratios, usebase, usecom, usencom, calcmode, lnter, lnur]
         
         self.infotext_fields = [


### PR DESCRIPTION
According to some discussions of https://github.com/hako-mikan/sd-webui-regional-prompter/issues/55, I think it is more appropriate to manually specify the negative weight of lora in textencoder and U-net than a switch, similar to the way of additional network extensions. I'm not too sure about the naming rules, it might need a little tweaking.