### PR TITLE
Revert "#91"

### DIFF
--- a/scripts/regions.py
+++ b/scripts/regions.py
@@ -275,7 +275,7 @@ def makeimgtmp(aratios,mode,usecom,usebase,inprocess = False):
         aratios2r = [1]
     else:
         (aratios2r,aratios2) = split_l2(aratios, DELIMROW, DELIMCOL, 
-                                        indsingles = True, fmap = ffloatd(1), indflip = False)
+                                        indsingles = True, fmap = ffloatd(1), indflip = indflip)
     # Change all splitters to breaks.
     (aratios2,aratios2r) = ratiosdealer(aratios2,aratios2r)
     


### PR DESCRIPTION
This reverts commit 0f52b58a55c8179701d437e2b536457e547b6c9d.

#91 stems from user's misunderstanding of the feature, which was clarified. No fix needed.
Commas always correspond to columns (except in 1d mode), and semicolons to rows, in line with ADDROW / ADDCOL. Interpreting them as "inner" and "outer" would make the feature more confusing to explain to the average joe, I think, even though it would grant better symmetry.