### PR TITLE
Bugfix - Localised lactive in cfg callbacks.

### DIFF
--- a/scripts/latent.py
+++ b/scripts/latent.py
@@ -114,7 +114,7 @@ def denoiser_callback_s(self, params: CFGDenoiserParams):
         
             att.maskready = True
 
-    if lactive or self.lpactive:
+    if self.lactive or self.lpactive:
         xt = params.x.clone()
         ict = params.image_cond.clone()
         st =  params.sigma.clone()
@@ -133,7 +133,7 @@ def denoiser_callback_s(self, params: CFGDenoiserParams):
                     params.text_cond[b+a*self.batch_size] = ct[a + b * areas]
 
 def denoised_callback_s(self, params: CFGDenoisedParams):
-    if lactive or self.lpactive:
+    if self.lactive or self.lpactive:
         x = params.x
         xt = params.x.clone()
         batch = self.batch_size

--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -315,6 +315,9 @@ class Script(modules.scripts.Script):
                 setuploras(self,p)
                 if self.debug : print(p.prompt)
                 seps = "AND"
+                # SBM It is vital to use local activation because callback registration is permanent,
+                # and there are multiple script instances (txt2img / img2img). 
+                self.lactive = True
 
             # seps = KEYBRK # SBM No longer is keybrk applied first.
 


### PR DESCRIPTION
Addresses #115.

Since callbacks essentially cannot be removed, and there might be multiple script instances (txt + img) each with its own callback which are all called during gen, the flag must be local per script in these callbacks.