### PR TITLE
Fix default value for compare

### DIFF
--- a/scripts/attention.py
+++ b/scripts/attention.py
@@ -91,7 +91,7 @@ def hook_forward(self, module):
             print("module : ", getattr(module, self.layer_name,None))
 
         if self.xsize == 0: self.xsize = x.shape[1]
-        if "input" in getattr(module, self.layer_name,None):
+        if "input" in getattr(module, self.layer_name,""):
             if x.shape[1] > self.xsize:
                 self.in_hr = True
 


### PR DESCRIPTION
Without this the default behaviour in Automatic1111 when following the guide is to fail with an error stating that the NoneType is not iterable.