### PR TITLE
#316: hirresscaler expects a 4th parameter, ...

### DIFF
--- a/scripts/attention.py
+++ b/scripts/attention.py
@@ -61,7 +61,7 @@ def main_forward(module,x,context,mask,divide,isvanilla = False,userpp = False,t
 
     global pmaskshw,pmasks
 
-    if inhr and not hiresfinished: hiresscaler(height,width,attn)
+    if inhr and not hiresfinished: hiresscaler(height,width,attn,h)
 
     if userpp and step > 0:
         for b in range(attn.shape[0] // 8):


### PR DESCRIPTION
h appears to be the correct variable to use here based on local tests.

Regression introduced in b6e987f where positional argument was added to `hiresscaler` definition, but the call to `hiresscaler` in `main_forward` was not updated accordingly.

Manual testing example:

![Screenshot_2024-07-09_02-56-52](https://github.com/hako-mikan/sd-webui-regional-prompter/assets/25534016/be33f992-9d83-4273-becc-10aba3e73183)