### PR TITLE
Fix: Improve User Experience for Mask Mode Workflows

### DIFF
--- a/scripts/regions.py
+++ b/scripts/regions.py
@@ -767,7 +767,7 @@ def create_canvas(h, w, indwipe = True):
 # If there's no base, remainder goes to first mask.
 # If there's a base, it will receive its own remainder mask, applied at 100%.
 def inpaintmaskdealer(self, p, bratios, usebase, polymask):
-    prompt = p.prompt
+    prompt = p.all_prompts[0]
     if self.optbreak:prompt = prompt.replace(KEYBRK, "")
     if self.debug: print("in inpaintmaskdealer",prompt)
     if KEYCOMM in prompt: prompt = prompt.split(KEYCOMM,1)[1]

--- a/scripts/regions.py
+++ b/scripts/regions.py
@@ -682,7 +682,7 @@ def detect_polygons(img,num):
     print("Region sketch size", skimg.shape)    
     return skimg, num + 1 if (num >= 0 and num + 1 <= CBLACK) else num
 
-def detect_mask(img, num, mult = CBLACK):
+def detect_mask(img, num, mult = CBLACK, color = None):
     """Extract specific colour and return mask.
     
     Multiplier for correct display.
@@ -696,18 +696,22 @@ def detect_mask(img, num, mult = CBLACK):
     if img is None:
         return None
     indnot = False
-    if num < 0: # Detect unmasked region.
-        if INDCOLREPL: # In replacement mode, all colours are either region or white.
-            color = np.array(COLWHITE).reshape([1,1,CCHANNELS])
-        else: # In nonrepl mode, mask all the regions and invert.
-            color = np.array(list(REGUSE.values())) # nx3
-            color = np.moveaxis(color,-1,0) # 3xn
-            color = color.reshape(1,1,*color.shape) # 1x1x3xn
-            img = img.reshape(*img.shape,1) # Same.
-            indnot = True
-    else:
-        color = deterministic_colours(int(num) + 1)[-1]
-        color = color.reshape([1,1,CCHANNELS])
+    if color is None: # If no color was passed in, generate it.
+        if num < 0: # Detect unmasked region.
+            if INDCOLREPL: # In replacement mode, all colours are either region or white.
+                color = np.array(COLWHITE).reshape([1,1,CCHANNELS])
+            else: # In nonrepl mode, mask all the regions and invert.
+                color = np.array(list(REGUSE.values())) # nx3
+                color = np.moveaxis(color,-1,0) # 3xn
+                color = color.reshape(1,1,*color.shape) # 1x1x3xn
+                img = img.reshape(*img.shape,1) # Same.
+                indnot = True
+        else:
+            color = deterministic_colours(int(num) + 1)[-1]
+            color = color.reshape([1,1,CCHANNELS])
+    else: # A color was provided, use it.
+        color = np.array(color).reshape([1,1,CCHANNELS])
+
     if indnot: # Negation of a list of regions.
         mask = (~(img == color)).all(-1).all(-1)
         mask = mask * mult
@@ -774,8 +778,8 @@ def inpaintmaskdealer(self, p, bratios, usebase, polymask):
     # Sort colour dict by key, return value for masking.
     #for _,c in sorted(REGUSE.items(), key = lambda x: x[0]):
 
-    for c in sorted(REGUSE.keys()):
-        m = detect_mask(polymask, c, 1)
+    for c, color_val in sorted(REGUSE.items()):
+        m = detect_mask(polymask, c, 1, color=color_val)
         if VARIANT != 0:
             m = m[:-VARIANT,:-VARIANT]
         if m.any():


### PR DESCRIPTION
Hello! This PR resolves a couple of issues related to the "Mask" mode.

While these bugs have workarounds, they can create a confusing experience for new users. I decided to fix them to make the masking workflow more intuitive and reliable.

This pull request includes two primary fixes:

1. Fixes Color Mismatch for Uploaded Masks
  - The Bug: When a user uploads a pre-made mask, generation fails due to a subtle color mismatch caused by floating-point inaccuracies during color standardization. The workaround was to manually click through and "fix" each region.
  - The Fix: The code now ensures the exact color value from the uploaded image is used during generation, making the process work as expected without any workarounds.

2. Fixes ADDCOL/ADDROW Crash in Mask Mode (Fixes #407)
  - The Bug: Using ADDCOL or ADDROW in a prompt while in Mask mode causes an IndexError crash because an internal function was only looking for the BREAK keyword. The workaround was to manually replace ADDCOL with BREAK.
  - The Fix: The internal logic has been corrected to properly recognize all valid separator keywords, making ADDCOL and ADDROW work as intended in Mask mode.

---
Testing:
I have tested these fixes on my local Automatic1111 Web UI, and they are working correctly.

Implementation Details:
These fixes were developed with the assistance of the Gemini CLI, using the Gemini Pro 2.5 model.