### PR TITLE
Fix compatibility with SD Forge Neo (it removed sd_hijack module)

### DIFF
--- a/scripts/latent.py
+++ b/scripts/latent.py
@@ -1,7 +1,7 @@
 import copy
 from pprint import pprint
 import torch
-from modules import devices, shared, extra_networks, sd_hijack
+from modules import devices, shared, extra_networks
 from modules.script_callbacks import CFGDenoisedParams, CFGDenoiserParams
 from torchvision.transforms import InterpolationMode, Resize  # Mask.
 import scripts.attention as att
@@ -11,6 +11,11 @@ from scripts.attention import makerrandman
 from modules import launch_utils
 forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag() == "neo" 
 reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag() == "classic"
+
+try:
+    from modules import sd_hijack
+except (ImportError, ModuleNotFoundError):
+    sd_hijack = None
 
 if forge:
     from modules.script_callbacks import AfterCFGCallbackParams, on_cfg_after_cfg


### PR DESCRIPTION
### Issue

* #414

> SD forge neo has made changes that removes sd_hijack.py from modules, so Regional Prompter errors when forge starts and does not appear in the row of tabs.
> 
> Apparently the sd_hijack is a redundant module from auto1111 - best I can tell it just passes every time but I don't know enough to suggest more.

### Implementation

The same change as in a1111-sd-webui-tagcomplete extension:

* https://github.com/DominikDoom/a1111-sd-webui-tagcomplete/commit/a46c5ce04420aa313daed24e84f9ec7fa435bdce

----

Fixes #414