### PR TITLE
Fix Forge Neo / Classic detection for new git_tag() format

### DIFF
--- a/scripts/attention.py
+++ b/scripts/attention.py
@@ -9,8 +9,8 @@ from torch import nn, einsum
 from einops import rearrange, repeat
 
 from modules import launch_utils
-forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag() == "neo" 
-reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag() == "classic"
+forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag().split(" ")[0] == "neo"
+reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag().split(" ")[0] == "classic"
 
 TOKENSCON = 77
 TOKENS = 75

--- a/scripts/latent.py
+++ b/scripts/latent.py
@@ -1,7 +1,7 @@
 import copy
 from pprint import pprint
 import torch
-from modules import devices, shared, extra_networks, sd_hijack
+from modules import devices, shared, extra_networks
 from modules.script_callbacks import CFGDenoisedParams, CFGDenoiserParams
 from torchvision.transforms import InterpolationMode, Resize  # Mask.
 import scripts.attention as att
@@ -9,8 +9,13 @@ from scripts.regions import floatdef
 from scripts.attention import makerrandman
 
 from modules import launch_utils
-forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag() == "neo" 
-reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag() == "classic"
+forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag().split(" ")[0] == "neo"
+reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag().split(" ")[0] == "classic"
+
+try:
+    from modules import sd_hijack
+except (ImportError, ModuleNotFoundError):
+    sd_hijack = None
 
 if forge:
     from modules.script_callbacks import AfterCFGCallbackParams, on_cfg_after_cfg

--- a/scripts/rp.py
+++ b/scripts/rp.py
@@ -30,8 +30,8 @@ disable_image_editor = getattr(shared.opts,"regprp_" + OPT_RP_DISABLE_IMAGE_EDIT
 USE_OLD_ACTIVE = "old_active_check"
 use_old_active = getattr(shared.opts,"regprp_" + USE_OLD_ACTIVE, False)
 
-forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag() == "neo" 
-reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag() == "classic"
+forge = launch_utils.git_tag()[0:2] == "f2" or launch_utils.git_tag().split(" ")[0] == "neo"
+reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag().split(" ")[0] == "classic"
 print(f"Forge: {forge}, reForge: {reforge}")
 
 KEYBRK_R = "RP_TEMP_REPLACE"


### PR DESCRIPTION
## 概要 / Summary

Forge Classic / Neo が `launch_utils.git_tag()` の返り値を `"neo"` → `"neo 2.27"`(`"<version> <release>"` 形式)に変更したため([Haoming02/sd-webui-forge-classic@c06f73dc](https://github.com/Haoming02/sd-webui-forge-classic/commit/c06f73dc))、完全一致による Forge 判定が外れて A1111 用コードパスに落ち、生成のたびに以下のエラーが発生します:

Forge Classic / Neo changed the return value of `launch_utils.git_tag()` from `"neo"` to `"neo 2.27"` (`"<version> <release>"` format) in [Haoming02/sd-webui-forge-classic@c06f73dc](https://github.com/Haoming02/sd-webui-forge-classic/commit/c06f73dc). The exact-match Forge detection no longer matches, so the extension falls into the A1111 code path and crashes on every generation:

```
File ".../extensions/sd-webui-regional-prompter/scripts/latent.py", line 764, in unloadlorafowards
    emb_db = sd_hijack.model_hijack.embedding_db
             ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'model_hijack'
```

## 変更内容 / Changes

- `rp.py` / `latent.py` / `attention.py`: Forge / reForge 判定を空白区切りの先頭トークンでの比較に変更。旧形式(`"neo"` / `"classic"`)と新形式(`"neo 2.27"` など)の両方で動作します。
  Compare only the first whitespace-separated token in the Forge / reForge detection. Works with both the old (`"neo"` / `"classic"`) and new (`"neo 2.27"`) formats.
- `latent.py`: `sd_hijack` の import を try/except で保護。Forge Neo には `modules/sd_hijack` が存在しないため、無条件 import だと判定に到達する前に ImportError になります。
  Guard the `sd_hijack` import with try/except — Forge Neo no longer ships `modules/sd_hijack`, so the unconditional top-level import raises ImportError before the detection code is even reached.

## 動作確認 / Tested

- Forge Neo 2.27(git_tag = `"neo 2.27"`)で起動ログが `Forge: True, reForge: False` となり、エラーが解消することを確認。
  Verified on Forge Neo 2.27 (git_tag = `"neo 2.27"`): the startup log now shows `Forge: True, reForge: False` and the crash is gone.
